### PR TITLE
Stream data in order it was received

### DIFF
--- a/zipstream/__init__.py
+++ b/zipstream/__init__.py
@@ -191,7 +191,7 @@ class ZipFile(zipfile.ZipFile):
 
     def flush(self):
         while self.paths_to_write:
-            kwargs = self.paths_to_write.pop()
+            kwargs = self.paths_to_write.pop(0)
             for data in self.__write(**kwargs):
                 yield data
 


### PR DESCRIPTION
When flushing, stream out the iterators in First in first out order. Python `pop()` with no arguments would take the last path but I think it makes sense to stream the first things first.

We ran into this issue where we add a bunch of files which depend on long-running futures to provide the data. The futures hit a server which processes them roughly in order, so we get better streaming performance if we make this change.